### PR TITLE
Add a note that the driver is unnecessary now

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # metabase-cubejs-driver
 
+> Since May 2022, Cube has the official [SQL API](https://cube.dev/docs/backend/sql) that works with Metabase, making this driver unnecessary.  
+> Please see the docs on [using Cube with Metabase](https://cube.dev/docs/config/downstream/metabase). 
+
 [![Latest Release](https://img.shields.io/github/v/release/pyrooka/metabase-cubejs-driver)](https://img.shields.io/github/v/release/pyrooka/metabase-cubejs-driver)
 [![GitHub license](https://img.shields.io/badge/license-AGPL-05B8CC.svg)](https://raw.githubusercontent.com/pyrooka/metabase-cubejs-driver/master/LICENSE)
 


### PR DESCRIPTION
Huge thanks for maintaining this driver! It looks like its time has come to an end since Cube now has a native and supported way to connect to Metabase through Cube's SQL API. It might be good to add this note to this repository and archive it, just like it's done here: https://github.com/pyrooka/metabase-cubejs-driver